### PR TITLE
FIX: BuildDir / --builddir

### DIFF
--- a/clyde
+++ b/clyde
@@ -36,6 +36,7 @@ local CLYDECONF = "/etc/clyde.conf"
 local DBPATH = "/var/lib/pacman/"
 local CACHEDIR = "/var/cache/pacman/pkg/"
 local LOGFILE = "/var/log/pacman.log"
+local BUILDDIR = "/tmp"
 local clydeconf = require "clydelib.config"
 
 local PACKAGE = "clyde"
@@ -135,6 +136,7 @@ local function usage(op, myname)
         printf(g("  -r, --root <path>    set an alternate installation root\n"))
         printf(g("  -b, --dbpath <path>  set an alternate database location\n"))
         printf(g("      --cachedir <dir> set an alternate package cache location\n"))
+        printf(g("      --builddir <dir> set an alternate package build location\n"))
         printf(g("      --editor <prg>   edit the PKGBUILD with the configured editor\n"))
         printf(g("      --color          enable colors\n"))
         printf(g("      --nocolor        disable colors\n"))
@@ -306,6 +308,7 @@ local longopts = {
         {"repos",       "no_argument",      0,  'OP_REPOS'},
         {"getpkgbuild", "no_argument",      0,  'G'},
         {"user",        "required_argument",0,  'OP_BUILD'},
+        {"builddir",    "required_argument",0,  'OP_BUILDDIR'},
     --[[
     --pacman feature functions
     --]]
@@ -401,6 +404,15 @@ local longopts = {
         ['G'] = settrans('PM_OP_GETPKG');
         ['OP_BUILD'] = function(opt)
             config.op_s_build_user = opt
+        end;
+        ['OP_BUILDDIR'] = function(opt)
+            local writable = os.rename(opt, opt)
+            if (not writable) then
+                lprintf("LOG_DEBUG", "cannot access specified build directory, defaulting.\n")
+                config.builddir = BUILDDIR
+            else
+                config.builddir = opt
+            end
         end;
         --[[
         --pacman feature functions
@@ -652,6 +664,8 @@ local function config_init(uid)
                 "#ReposOnly";
                 "#You must set this to a normal user to install packages from AUR safely while running without sudo";
                 "BuildUser = "..util.getbuilduser();
+                "#Modify the following line to specify the directory in which clyde should build packages from AUR";
+                "#BuildDir = /tmp";
             }
             clydeconf = string.format(
                 "#\n# CLYDE OPTIONS\n#\n[clydeoptions]\nEditor = %s\n%s\n%s",
@@ -738,6 +752,18 @@ local function _parseconfig(file, givensection, givendb)
         if (not config.op_s_build_user) then
             config.op_s_build_user = str
             lprintf("LOG_DEBUG", "config: builduser\n")
+        end
+    end;
+    ['BuildDir'] = function(str)
+        if (not config.builddir) then
+            local writable = os.rename(str, str)
+            if (not writable) then
+                lprintf("LOG_DEBUG", "cannot access specified build directory, defaulting.\n")
+                config.builddir = BUILDDIR
+            else
+                config.builddir = str
+                lprintf("LOG_DEBUG", "config: builddir: %s\n", str)
+            end
         end
     end;
         --[[
@@ -981,6 +1007,10 @@ function main()
     ret = parseconfig(config.configfile)
     if (ret ~= 0) then
         cleanup(ret)
+    end
+
+    if (not config.builddir) then
+        config.builddir = BUILDDIR
     end
 
     if (config.stats) then

--- a/clydelib/aur.lua
+++ b/clydelib/aur.lua
@@ -48,9 +48,9 @@ end
 function download(host, file, user)
     local filename = file:match(".+/(.+)$")
     local foldername = file:match(".+/(.+)/.+$")
-    lfs.mkdir("/tmp/clyde-"..user)
-    lfs.mkdir("/tmp/clyde-"..user.."/"..foldername)
-    local f, err = io.open("/tmp/clyde-"..user.."/"..foldername.. "/" ..filename, "w")
+    lfs.mkdir(config.builddir.."/clyde-"..user)
+    lfs.mkdir(config.builddir.."/clyde-"..user.."/"..foldername)
+    local f, err = io.open(config.builddir.."/clyde-"..user.."/"..foldername.. "/" ..filename, "w")
     local received = 0
     local r, c, h = http.request {
         method = "HEAD",

--- a/clydelib/config.lua
+++ b/clydelib/config.lua
@@ -28,6 +28,7 @@ return {
 ['rootdir'] = false;
 ['dbpath'] = false;
 ['logfile'] = false;
+['builddir'] = false;
 --	/* TODO how to handle cachedirs? */
 ['op_q_isfile'] = false;
 ['op_q_info'] = 0;

--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -936,15 +936,15 @@ local function download_extract(target, currentdir)
     aur.dispatcher()
     --utilcore.umask(oldmask)
     if (not currentdir) then
-        lfs.chdir("/tmp/clyde-"..user.."/"..target)
-        os.execute("chmod 700 /tmp/clyde-"..user.."/"..target)
+        lfs.chdir(config.builddir.."/clyde-"..user.."/"..target)
+        os.execute("chmod 700 "..config.builddir.."/clyde-"..user.."/"..target)
         os.execute("bsdtar -xf " .. target .. ".tar.gz &>/dev/null")
         if (myuid == 0) then
-            os.execute("chown "..user..":users -R /tmp/clyde-"..user)
+            os.execute("chown "..user..":users -R "..config.builddir.."/clyde-"..user)
         end
     else
---        os.execute("mv /tmp/clyde-"..user.."/"..target.."/"..target..".tar.gz "..lfs.currentdir())
-        retmv = os.execute(string.format("mv /tmp/clyde-%s/%s/%s.tar.gz %s &>/dev/null",
+--        os.execute("mv "..config.builddir.."/clyde-"..user.."/"..target.."/"..target..".tar.gz "..lfs.currentdir())
+        retmv = os.execute(string.format("mv "..config.builddir.."/clyde-%s/%s/%s.tar.gz %s &>/dev/null",
             user, target, target, lfs.currentdir()))
         retex = os.execute("bsdtar -xf "..target..".tar.gz &>/dev/null")
         if(retex == 0 and retmv == 0) then
@@ -953,13 +953,13 @@ local function download_extract(target, currentdir)
             lprintf("LOG_ERROR", "could not extract %s.tar.gz\n", target)
         end
     end
---    os.execute("chmod 700 -R /tmp/clyde/"..target)
+--    os.execute("chmod 700 -R "..config.builddir.."/clyde/"..target)
 
 end
 
 local function customizepkg(target)
     local user = util.getbuilduser()
-    lfs.chdir("/tmp/clyde-"..user.."/"..target.."/"..target)
+    lfs.chdir(config.builddir.."/clyde-"..user.."/"..target.."/"..target)
     if (not config.noconfirm) then
         local editor
         if (not config.editor) then
@@ -1024,7 +1024,7 @@ local function installpkgs(targets)
     end
     local user = util.getbuilduser()
     local packagedir = getbasharrayuser("/etc/makepkg.conf", "PKGDEST", user)
-            or "/tmp/clyde-"..user.."/"..target.."/"..target
+            or config.builddir.."/clyde-"..user.."/"..target.."/"..target
 
     local pkgs = {}
     local toinstall = {}


### PR DESCRIPTION
... noticed too late that you are using four spaces in your code, so I converted my tabs to spaces. I closed the original pull request. Below is the original message text:

---

Hi there,

I've added options (command line and config file) to allow the user to specify the build directory (prefix) clyde should use when building packages from AUR. If nothing is specified or the directory is not writable, clyde defaults to "/tmp" as before.

This change addresses issue 82 in the issue tracker:
https://github.com/Kiwi/clyde/issuesearch?state=open&q=tmp#issue/82

Please let me know if you'd want me to change anything.

The one thing I dislike about my change is that a conditional statement in the main function had to be added to check if the config.builddir key has actually been set or shall default. I feel that there might be a better place to put this check.

Best,
rekado
