### PR TITLE
[PATCH] Fix to bug causing wrong logs on upgrades

### DIFF
--- a/clydelib/callback.lua
+++ b/clydelib/callback.lua
@@ -413,7 +413,7 @@ trans_event_lookup = {
         ["done"] = function(evt)
                        alpm.logaction(string.format("upgraded %s (%s -> %s)\n",
                                                     evt.new:pkg_get_name(),
-                                                    evt.new:pkg_get_version(),
+                                                    evt.old:pkg_get_version(),
                                                     evt.new:pkg_get_version()))
                        util.display_new_optdepends(evt.old, evt.new)
                        io.stdout:flush()


### PR DESCRIPTION
(Sorry, Kiwi, for the duplicate mail, I figured I should figure out the github thing anyway.)

I changed one line in one file to solve bug nr. 23 about wrong logs being printed to pacman.log on updates.
Please consider pulling this change as atm the logs are pretty useless to backtrack package upgrades..

Thanks,
Ramses de Norre
