### PR TITLE
Missing declaration in aur.lua

### DIFF
--- a/clydelib/aur.lua
+++ b/clydelib/aur.lua
@@ -7,6 +7,7 @@ local ltn12   = require "ltn12"
 local zlib    = require "zlib"
 local yajl    = require "yajl"
 local C       = colorize
+local alpm    = require "lualpm"
 
 local util    = require "clydelib.util"
 local printf  = util.printf


### PR DESCRIPTION
I think there was a declaration missing in aur.lua. I'm by no means a lua guru though, so please review before pulling.

This solves a crash of clyde on running "clyde -S clyde-git", before I got:

```
lua: ./clydelib/aur.lua:299: attempt to index global 'alpm' (a nil value)
stack traceback:
    ./clydelib/aur.lua:299: in function <./clydelib/aur.lua:298>
    [C]: in function 'sort'
    ./clydelib/aur.lua:302: in function 'installpkg'
    ./clydelib/sync.lua:1140: in function <./clydelib/sync.lua:1070>
    (tail call): ?
    ./clydelib/sync.lua:1547: in function 'clyde_sync'
    ./clydelib/sync.lua:1553: in function <./clydelib/sync.lua:1552>
    (tail call): ?
    /usr/bin/clyde:1054: in function 'main'
    /usr/bin/clyde:1112: in main chunk
    [C]: ?
```
