### PR TITLE
Upgrade show versions

### DIFF
--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1199,7 +1199,6 @@ local function find_installed_aur ()
     print( C.blub("::") .. C.bright(" Identifying AUR packages..."))
 
     local aurpkgs = {}
-    local aurversions = {}
     for i, foreigner in ipairs( foreign_pkgs ) do
         local name, version = foreigner.name, foreigner.version
 
@@ -1227,7 +1226,7 @@ local function find_installed_aur ()
     print( C.blub("  -> ") .. C.bright
        .. "Identified " .. #aurpkgs .. " AUR packages." .. C.reset )
 
-    return aurpkgs, aurversions
+    return aurpkgs
 end
 
 local function sync_trans(targets)
@@ -1236,7 +1235,6 @@ local function sync_trans(targets)
     local transret
     local data = {}
     local aurpkgs = {}
-    local aurversions = {}
     local sync_dbs = alpm.option_get_syncdbs()
     local function transcleanup()
         if (trans_release() == -1) then
@@ -1269,7 +1267,7 @@ local function sync_trans(targets)
 
         if (config.op_s_upgrade_aur) then
             config.op_s_upgrade = 0
-            aurpkgs, aurversions = find_installed_aur()
+            aurpkgs = find_installed_aur()
             targets = pkgs_to_names(aurpkgs)
         end
     else

--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1244,7 +1244,7 @@ local function sync_trans(targets)
     end
     local function aurpkgs_to_names(pkgs)
         local names = {}
-        for name, version in pairs(aurpkgs) do
+        for name, version in pairs(pkgs) do
             tblinsert(names, name)
         end
         return names
@@ -1329,7 +1329,7 @@ local function sync_trans(targets)
 
                         if (jsonresults.results.Name) then
                             found = true
-                            tblinsert(aurpkgs, {name=targ, version=jsonresults.results.Version})
+                            aurpkgs[targ] = jsonresults.results.Version
                         end
 
                     end

--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1219,7 +1219,7 @@ local function find_installed_aur ()
         -- If a newer version is on the AUR, then add it to our list
         local aurver = aur_version( name )
         if aurver and alpm.pkg_vercmp( aurver, version ) > 0 then
-            table.insert( aurpkgs, {name=name, version=aurver} )
+            aurpkgs[name] = aurver
         end
     end
 
@@ -1242,10 +1242,10 @@ local function sync_trans(targets)
         end
         return retval
     end
-    local function pkgs_to_names(pkgs)
+    local function aurpkgs_to_names(pkgs)
         local names = {}
-        for i, pkg in ipairs(aurpkgs) do
-            tblinsert(names, pkg.name)
+        for name, version in pairs(aurpkgs) do
+            tblinsert(names, name)
         end
         return names
     end
@@ -1268,7 +1268,7 @@ local function sync_trans(targets)
         if (config.op_s_upgrade_aur) then
             config.op_s_upgrade = 0
             aurpkgs = find_installed_aur()
-            targets = pkgs_to_names(aurpkgs)
+            targets = aurpkgs_to_names(aurpkgs)
         end
     else
         for i, targ in ipairs(targets) do
@@ -1476,7 +1476,7 @@ local function sync_trans(targets)
 
     if (next(aurpkgs)) then
         transcleanup()
-        return aur_install(pkgs_to_names(aurpkgs))
+        return aur_install(aurpkgs_to_names(aurpkgs))
     else
         return transcleanup()
     end

--- a/clydelib/util.lua
+++ b/clydelib/util.lua
@@ -495,14 +495,14 @@ function display_aur_targets(pkgs, install)
     end
 
     printf("\n")
-    for i, pkg in ipairs(pkgs) do
-        local local_pkg = localdb:db_get_pkg(pkg.name)
+    for name, version in pairs(pkgs) do
+        local local_pkg = localdb:db_get_pkg(name)
 
         if (install and local_pkg ~= nil) then
-            str = string.format("%s: %s -> %s", pkg.name,
-                                local_pkg:pkg_get_version(), pkg.version)
+            str = string.format("%s: %s -> %s", name,
+                                local_pkg:pkg_get_version(), version)
         else
-            str = string.format("%s: %s", pkg.name, pkg.version)
+            str = string.format("%s: %s", name, version)
         end
 
         tblinsert(targets, str)

--- a/clydelib/util.lua
+++ b/clydelib/util.lua
@@ -486,7 +486,7 @@ function display_targets(pkgs, install)
     end
 end
 
-function display_aur_targets(pkgs, versions, install)
+function display_aur_targets(pkgs, install)
     local targets = {}
     local localdb = alpm.option_get_localdb()
 
@@ -496,13 +496,13 @@ function display_aur_targets(pkgs, versions, install)
 
     printf("\n")
     for i, pkg in ipairs(pkgs) do
-        local local_pkg = localdb:db_get_pkg(pkg)
+        local local_pkg = localdb:db_get_pkg(pkg.name)
 
         if (install and local_pkg ~= nil) then
-            str = string.format("%s: %s -> %s", pkg,
-                                local_pkg:pkg_get_version(), versions[pkg])
+            str = string.format("%s: %s -> %s", pkg.name,
+                                local_pkg:pkg_get_version(), pkg.version)
         else
-            str = string.format("%s: %s", pkg, versions[pkg])
+            str = string.format("%s: %s", pkg.name, pkg.version)
         end
 
         tblinsert(targets, str)


### PR DESCRIPTION
This commits make clyde show the currently installed and the to-be installed versions on upgrading, both for repo and for aur packages.

I still have to test it a bit, but I wanted to let you know about it already because I had to redo quite a bit due to the commits from yesterday to sync.lua.

Cheers.
