### PR TITLE
Aur fixes

### DIFF
--- a/clydelib/aur.lua
+++ b/clydelib/aur.lua
@@ -128,7 +128,9 @@ function rpc_info ( name )
                                      create = create_socket,
                                      sink   = ltn12.sink.table( chunks ) }
     if not ret or code ~= 200 then
-        error( "HTTP request for info RPC failed: " .. code )
+        -- Make clyde continue if retrieval of an AUR pkg fails
+        --TODO should we somehow show a warning?
+        return nil
     end
 
     local jsontxt = table.concat( chunks, "" )

--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1126,8 +1126,9 @@ local function find_installed_aur ()
             dispname = dispname .. "..."
         end
 
-        local message = string.format( "\r %-23s%3.0f/%3.0f",
+        local message = string.format( " %-23s%3.0f/%3.0f",
                                        dispname, i, foreign_count )
+
         io.write( message )
         callback.fill_progress( math.floor( i*100/foreign_count ),
                                 math.ceil( i*100/foreign_count ),


### PR DESCRIPTION
Two small fixes:
- For some reason a carriage return character (\r) was included in the string that shows the pkg name while retrieving AUR pkg info, as this character is not printed but does get counted in the string length, it made the progress bar one character too short. I don't think this character was really needed here, but correct me if I'm wrong.
- When retrieving info for an AUR pkg fails (e.g. a network time-out) clyde crashed, IMHO it would be better if clyde would continue retrieving other packages and just skip the one causing the time-out. I'm not sure why these time-outs occur from time to time, but, at least for me, they happen every once in a while.
  These errors currently also lead to users having to manually 'rm /var/lib/pacman/db.lck".
