### PR TITLE
Made it so that a single not found package would not make the entire process stop.

### DIFF
--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1266,9 +1266,12 @@ local function sync_trans(targets)
                 end
 
                 if (not found) then
-                    eprintf("LOG_ERROR", g("'%s': not found in sync db\n"), targ)
-                    retval = 1
-                    return transcleanup()
+                    if #targets == 1 then 
+						eprintf("LOG_ERROR", g("'%s': not found in sync db\n"), targ)
+					else
+						eprintf("LOG_ERROR", g("'%s': not found in sync db, skipping\n"), targ)
+					end
+					targets[i] = "nfound"
                 end
             until 1
         end
@@ -1320,7 +1323,7 @@ local function sync_trans(targets)
         {}, {}, {}, {}, {}
 
     for i, pkg in ipairs(targets) do
-        if (not pacmaninstallable(pkg)) then
+        if (not pacmaninstallable(pkg) and not (pkg == "nfound")) then
             tblinsert(possibleaur, pkg)
         end
     end

--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1271,7 +1271,7 @@ local function sync_trans(targets)
 					else
 						eprintf("LOG_ERROR", g("'%s': not found in sync db, skipping\n"), targ)
 					end
-					targets[i] = "nfound"
+					targets[i] = 0
                 end
             until 1
         end
@@ -1323,7 +1323,7 @@ local function sync_trans(targets)
         {}, {}, {}, {}, {}
 
     for i, pkg in ipairs(targets) do
-        if (not pacmaninstallable(pkg) and not (pkg == "nfound")) then
+        if (not pacmaninstallable(pkg) and not (pkg == 0)) then
             tblinsert(possibleaur, pkg)
         end
     end


### PR DESCRIPTION
Example:

:: blah package not found, searching for group...
:: blah group not found, searching AUR...
error: 'blah': not found in sync db, skipping
:: lanes package not found, searching for group...
:: lanes group not found, searching AUR...

==> Installing the following packages from AUR
Targets (1): lanes  

==> Proceed with installation? [Y/n] 

Instead of:

:: blah package not found, searching for group...
:: blah group not found, searching AUR...
error: 'blah': not found in sync db

I did this kind of hackily. (although the code is really all over the place, so it was hard for me to figure most of it out)
