### PR TITLE
Handle missing user in /etc/password when building

### DIFF
--- a/clydelib/aur.lua
+++ b/clydelib/aur.lua
@@ -91,6 +91,7 @@ end
 function chown_builduser ( path, ... )
     local buser = get_builduser()
     local pwent = utilcore.getpwnam( buser )
+        or error( "unable to find user " .. buser )
     util.chown( buser, pwent.gid, path, ... )
 end
 

--- a/clydelib/sync.lua
+++ b/clydelib/sync.lua
@@ -1064,8 +1064,13 @@ local function aur_install(targets)
 
                 -- Don't let root hog our new package files...
                 if utilcore.geteuid() == 0 then
-                    aur.chown_builduser( pkgpath )
-                    aur.chown_builduser( pkgdir, '-R' )
+                    local chown_status = pcall(function ()
+                        aur.chown_builduser( pkgpath )
+                        aur.chown_builduser( pkgdir, '-R' )
+                    end)
+                    if not chown_status then
+                        lprintf("LOG_WARNING", g("unable to change ownership of build directory\n"))
+                    end
                 end
 
                 if not config.noconfirm then


### PR DESCRIPTION
The getpwnam() function returns NULL if a user is not found in
/etc/password, but errno will not be set. In this case nil is returned,
and an exception is thrown.

The patch adds handling for this edge case. A warning will be printed
that ownership can not be changed for the build directory, as this is
not a fatal error.
